### PR TITLE
ci: upload-artifact@v3 is deprecated. Upgrading to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes

actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024

# Why is this change being proposed?
